### PR TITLE
商品一覧表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,4 +66,4 @@ gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
 
-
+gem 'activestorage-validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       activejob (= 6.0.4.1)
       activerecord (= 6.0.4.1)
       marcel (~> 1.0.0)
+    activestorage-validator (0.1.4)
+      rails (>= 5.2.0)
     activesupport (6.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -269,6 +271,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  activestorage-validator
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Association
 |text               |text         |null:false                    |
 |category_id        |integer      |null:false                    |カテゴリー
 |sales_status_id    |integer      |null:false                    |商品の状態
-|shipping_fee_id    |integer      |null:false                    |送料
+|shipping_fee_id    |integer      |null:false                    |発送料の負担
 |prefecture_id      |integer      |null:false                    |県
 |date_of_shipment_id|integer      |null:false                    |出荷日
 |price              |integer      |null:false                    |ねだん

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:create]
 
- #def index
+ #def index *＊商品一覧機能の実装までコメントアウト
  # @item = Item.order("created_at DESC")
  #end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:create]
 
- #def index *＊商品一覧機能の実装までコメントアウト
- # @item = Item.order("created_at DESC")
- #end
+  def index 
+   @item = Item.order("created_at DESC")
+  end
 
  def new
    @item = Item.new
@@ -26,7 +26,6 @@ class ItemsController < ApplicationController
   .merge(user_id: current_user.id)
 end
 
- 
 
   
 

--- a/app/controllers/order_controller.rb
+++ b/app/controllers/order_controller.rb
@@ -1,7 +1,7 @@
 #class OrderController < ApplicationController
 
  # def new
-  #end
+  #end**購入機能の際に作成するためコメントアウト
   
 
 #end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,4 +2,5 @@
   #has_one :address
   #belongs_to :user
   #belongs_to :item
-#end
+#end**購入機能の際実装するのでそれまでコメントアウト
+#o-da-のマイグレーションファイルも購入機能の実装の際に使用するのでその時に生成させる

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,12 +131,12 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-image", class: "item-img" %>
+           <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
@@ -147,7 +147,7 @@
             <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%=price %>円<br><%= 'shipping_fee' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee[:name]%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -161,7 +161,7 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @items.empty? %>
+      <%#if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,7 +179,7 @@
         </div>
         <% end %>
       </li>
-      <%end%>
+      <%#end%>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,10 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-    <% unless @item == nil %>
+    <% unless @item [0] == nil %>
       <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item.id) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
            <%= image_tag item.image, class: "item-img" %>
 
@@ -178,8 +177,7 @@
         <% end %>
       </li>
       <%end%>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,6 +129,7 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% unless @item == nil %>
       <% @item.each do |item| %>
       <li class='list'>
         <%= link_to item_path(item.id) do %>
@@ -156,12 +157,9 @@
         </div>
         <% end %>
       </li>
-      <%end%>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%#if @items.empty? %>
+      <% end %>
+  
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,7 +177,7 @@
         </div>
         <% end %>
       </li>
-      <%#end%>
+      <%end%>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
@@ -190,5 +188,5 @@
   <span class='purchase-btn-text'>出品する</span>
 
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-<% end %>
+  <% end %>
 <%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,10 +129,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @item.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag "item-image", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%=price %>円<br><%= 'shipping_fee' %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +156,12 @@
         </div>
         <% end %>
       </li>
+      <%end%>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,6 +179,7 @@
         </div>
         <% end %>
       </li>
+      <%end%>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -39,6 +39,7 @@
       </div>
     </div>
     <%# /商品名と商品説明 %>
+    
     <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,6 +1,6 @@
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), root_path %>date_of_shipment_id
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), root_path %>
 
   </header>
   <div class="items-sell-main">
@@ -39,7 +39,7 @@
       </div>
     </div>
     <%# /商品名と商品説明 %>
-    
+
     <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>


### PR DESCRIPTION
what
フリマアプリにおける商品表示機能を実装させること


Why

商品一覧表示ページは、ログイン状況に関係なく、誰でも見ることができること。
出品されている商品が一覧で表示されること。
画像が表示されており、画像がリンク切れなどにならないこと（デプロイのタスクにあるとおり、実装中にHerokuの仕様による商品画像が適切に表示されなくなる問題は発生するが、最後にS3を導入することで、この問題は解消される）。
商品が出品されていない状態では、ダミーの商品情報が表示されること。
左上から、出品された日時が新しい順に表示されること。

-----

商品のデータがない場合は、ダミー商品が表示されている動画

https://i.gyazo.com/d950970456505aed91ceb9f2c1bc5200.mp4

商品のデータがある場合は、商品が一覧で表示されている動画
https://i.gyazo.com/8f8a6cb592eca808fb4dbddf9aa20294.mp4

----

よろしくお願い致します。